### PR TITLE
Simple grid for card links

### DIFF
--- a/src/components/grid.tsx
+++ b/src/components/grid.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+
+const Grid: React.FC<{
+  gridItems: GridItem[]
+}> = ({ gridItems }) => {
+  const cardLinks = gridItems.map(gridItem => (
+    <CardLink key={gridItem.id} gridItem={gridItem} />
+  ))
+  return (
+    <section
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(min(280px, 100%), 1fr))",
+        gap: "32px",
+        justifyItems: "center",
+        marginBottom: "64px",
+      }}
+    >
+      {cardLinks}
+    </section>
+  )
+}
+
+export interface GridItem {
+  id: string
+  title: string
+  backgroundImage: {
+    file: {
+      url: string
+    }
+  }
+}
+
+const CardLink: React.FC<{
+  gridItem: GridItem
+}> = ({ gridItem }) => (
+  <a
+    href="#"
+    style={{
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      width: "280px",
+      height: "280px",
+      backgroundImage: `url('${gridItem.backgroundImage.file.url}')`,
+      backgroundSize: "cover",
+      textDecoration: "none",
+      color: "white",
+      textTransform: "uppercase",
+      fontWeight: "bold",
+    }}
+  >
+    <h2
+      style={{
+        fontFamily: "Montserrat, sans-serif",
+      }}
+    >
+      {gridItem.title}
+    </h2>
+  </a>
+)
+
+export default Grid

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react"
+import Grid, { GridItem } from "./grid"
 import MarkdownRemark, { MarkdownRemarkNode } from "./markdownremark"
 import Quote from "./quote"
 import Video from "./video"
@@ -18,6 +19,7 @@ export interface SectionNode {
       url: string
     }
   }
+  gridItems?: GridItem[]
   slug?: string
 }
 
@@ -38,6 +40,8 @@ const Section: FC<SectionProps> = ({ title, node }) => {
     </div>
   ) : node.video ? (
     <Video url={node.video.file.url} />
+  ) : node.gridItems ? (
+    <Grid gridItems={node.gridItems} />
   ) : (
     <>{node.title && <Quote author={node.author}>{node.title}</Quote>}</>
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,6 +40,18 @@ export const query = graphql`
             }
           }
         }
+        ... on ContentfulGrid {
+          id
+          gridItems {
+            id
+            title
+            backgroundImage {
+              file {
+                url
+              }
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<img width="690" alt="Screen Shot 2020-09-14 at 23 16 39" src="https://user-images.githubusercontent.com/14876246/93139054-5eb13380-f6e0-11ea-87bc-a6c8fe3078a5.png">

Implements the grid content type to display card links in a grid. The grid rearranges items to fit an appropriate number of cards horizontally.