### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
-      - name: Set up Python 3.9.2
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9.1
+          python-version: '3.12'
           
       - name: Install dependencies
         run: pip install -r donationdb/requirements.txt

--- a/donationdb/payments/tests.py
+++ b/donationdb/payments/tests.py
@@ -45,5 +45,5 @@ class PaymentViewTestCase(TestCase):
 
         client = Client()
         response = client.get("/payments/success", request_parameters)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Pipeline seems to fail on #77 due to Python version being too old and missing.